### PR TITLE
Add dynamic PWA manifest so installed app opens to the sign's URL

### DIFF
--- a/pages/_document.js
+++ b/pages/_document.js
@@ -14,7 +14,6 @@ export default function Document() {
         <meta name='theme-color' content='#000000' />
 
         <link rel='apple-touch-icon' href='/icons/icon-192x192.png' />
-        <link rel='manifest' href='/manifest.json' />
       </Head>
       <body>
         <Main />

--- a/pages/api/manifest.js
+++ b/pages/api/manifest.js
@@ -1,0 +1,12 @@
+import baseManifest from '../../public/manifest.json';
+
+const VALID_START_URL = /^\/sign\/[a-zA-Z]{4}$|^\/$/;
+
+export default function handler(req, res) {
+  const { start_url } = req.query;
+  const safeStartUrl =
+    start_url && VALID_START_URL.test(start_url) ? start_url : '/';
+
+  res.setHeader('Content-Type', 'application/manifest+json');
+  res.json({ ...baseManifest, start_url: safeStartUrl });
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -79,6 +79,7 @@ export default function Home({ signIds }) {
         <meta name="apple-mobile-web-app-capable" content="yes"/>
         <meta name="apple-mobile-web-app-status-bar-style" content="white"/>
         <meta name="theme-color" content="#232338"/>
+        <link rel='manifest' href='/manifest.json' />
       </Head>
       <h1>Access your sign</h1>
       <h2>Welcome to subway sign</h2>

--- a/pages/sign/[sign].js
+++ b/pages/sign/[sign].js
@@ -61,6 +61,7 @@ export default function Home({
         <meta name="apple-mobile-web-app-capable" content="yes" />
         <meta name="apple-mobile-web-app-status-bar-style" content="white" />
         <meta name="theme-color" content="#232338" />
+        <link rel='manifest' href={`/api/manifest?start_url=/sign/${signId}`} />
       </Head>
       <Header
         signId={signId}


### PR DESCRIPTION
Creates a /api/manifest endpoint that accepts a start_url query param and returns the full manifest with that path set as start_url. The /sign/[sign] page now points its manifest link there (e.g. /api/manifest?start_url=/sign/abcd), so installing the PWA from that page will open directly to that sign. The root page keeps the static manifest.json with start_url: /.