### PR TITLE
Fix bottom tabs hidden in PWA standalone mode

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,7 +1,15 @@
 import '../styles/globals.scss'
+import Head from 'next/head'
 
 function MyApp({ Component, pageProps }) {
-  return <Component {...pageProps} />
+  return (
+    <>
+      <Head>
+        <meta name='viewport' content='width=device-width, initial-scale=1, viewport-fit=cover' />
+      </Head>
+      <Component {...pageProps} />
+    </>
+  )
 }
 
 export default MyApp

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,7 +1,28 @@
 import '../styles/globals.scss'
 import Head from 'next/head'
+import { useEffect } from 'react'
 
 function MyApp({ Component, pageProps }) {
+  useEffect(() => {
+    const viewport = window.visualViewport
+    if (!viewport) return
+
+    // Track the actual visible height (above the on-screen keyboard) so the
+    // layout shrinks instead of being overlaid/hidden by the keyboard.
+    const updateAppHeight = () => {
+      document.documentElement.style.setProperty('--app-height', `${viewport.height}px`)
+    }
+
+    updateAppHeight()
+    viewport.addEventListener('resize', updateAppHeight)
+    viewport.addEventListener('scroll', updateAppHeight)
+
+    return () => {
+      viewport.removeEventListener('resize', updateAppHeight)
+      viewport.removeEventListener('scroll', updateAppHeight)
+    }
+  }, [])
+
   return (
     <>
       <Head>

--- a/styles/Home.module.scss
+++ b/styles/Home.module.scss
@@ -5,6 +5,7 @@
 	@extend %helvetica;
 	width: 100vw;
 	height: 100dvh;
+	padding-bottom: env(safe-area-inset-bottom, 0px);
 	overflow-x: hidden;
 	font-size: 16px;
 

--- a/styles/Home.module.scss
+++ b/styles/Home.module.scss
@@ -4,7 +4,7 @@
 	@extend %vertical-center;
 	@extend %helvetica;
 	width: 100vw;
-	height: 100dvh;
+	height: var(--app-height, 100dvh);
 	padding-bottom: env(safe-area-inset-bottom, 0px);
 	overflow-x: hidden;
 	font-size: 16px;


### PR DESCRIPTION
Add a viewport meta tag with viewport-fit=cover and reserve the bottom
safe-area inset on the layout root so the tab bar clears the iOS home
indicator when running as an installed PWA.

https://claude.ai/code/session_018NrukQSNJP6Yvjoc9GKZXm